### PR TITLE
Add support for terminals that redirect input such as MINGW64

### DIFF
--- a/src/Verify.Terminal/Commands/ReviewCommand.cs
+++ b/src/Verify.Terminal/Commands/ReviewCommand.cs
@@ -57,7 +57,10 @@ public sealed class ReviewCommand : Command<ReviewCommand.Settings>
 
             AnsiConsole.WriteLine();
             AnsiConsole.MarkupLine($"[yellow b]Reviewing[/] [[{index + 1}/{snapshots.Count}]]");
+
+RenderDiff:
             AnsiConsole.Write(_snapshotRenderer.Render(diff, Math.Max(0, settings.ContextLines)));
+            ShowHelp();
 
             switch (ShowPrompt())
             {
@@ -69,6 +72,8 @@ public sealed class ReviewCommand : Command<ReviewCommand.Settings>
                     break;
                 case SnapshotAction.Skip:
                     continue;
+                case SnapshotAction.Unknown:
+                    goto RenderDiff;
             }
 
             if (!last)
@@ -82,40 +87,37 @@ public sealed class ReviewCommand : Command<ReviewCommand.Settings>
 
     private static SnapshotAction ShowPrompt()
     {
+        AnsiConsole.Markup("Accept this change [[[green]a[/],[red]r[/],[yellow]s[/]]]? ");
+
+        var answer = Console.ReadLine()?.ToLowerInvariant();
+
+        return answer switch
+        {
+            "a" => SnapshotAction.Accept,
+            "accept" => SnapshotAction.Accept,
+
+            "r" => SnapshotAction.Reject,
+            "reject" => SnapshotAction.Reject,
+
+            "s" => SnapshotAction.Skip,
+            "skip" => SnapshotAction.Skip,
+
+            _ => SnapshotAction.Unknown,
+        };
+    }
+
+    private static void ShowHelp()
+    {
         var grid = new Grid();
         grid.AddColumn(new GridColumn().PadLeft(4));
         grid.AddColumn(new GridColumn().PadLeft(4));
         grid.AddRow("[[[green]a[/]]]ccept", "[grey]keep the new snapshot[/]");
         grid.AddRow("[[[red]r[/]]]eject", "[grey]keep the old snapshot[/]");
         grid.AddRow("[[[yellow]s[/]]]kip", "[grey]keep both for now[/]");
+
         AnsiConsole.WriteLine();
         AnsiConsole.WriteLine();
         AnsiConsole.Write(grid);
-
-        try
-        {
-            AnsiConsole.Cursor.Hide();
-
-            while (true)
-            {
-                var key = Console.ReadKey(true);
-                var action = key.Key switch
-                {
-                    ConsoleKey.A => SnapshotAction.Accept,
-                    ConsoleKey.R => SnapshotAction.Reject,
-                    ConsoleKey.S => SnapshotAction.Skip,
-                    _ => (SnapshotAction?)null,
-                };
-
-                if (action != null)
-                {
-                    return action.Value;
-                }
-            }
-        }
-        finally
-        {
-            AnsiConsole.Cursor.Show();
-        }
+        AnsiConsole.WriteLine();
     }
 }

--- a/src/Verify.Terminal/SnapshotDiffAction.cs
+++ b/src/Verify.Terminal/SnapshotDiffAction.cs
@@ -2,6 +2,7 @@ namespace Verify.Terminal;
 
 public enum SnapshotAction
 {
+    Unknown,
     Accept,
     Reject,
     Skip,


### PR DESCRIPTION
Given that it's not possible to use `Console.ReadKey` when the input is redirected, I'm suggesting an approach using `Console.ReadLine` to display a prompt (with a visible cursor).

<img width="777" alt="image" src="https://user-images.githubusercontent.com/177608/205555545-c1a7b41c-e3e1-44c0-b992-261b3fd158d7.png">

In other words, the user now has to hit `<enter>` after typing one of the letters (`a`, `r`, or `s`).
As a bonus, the full words `accept`, `reject`, and `skip` are also valid. 

---

Closes #1
