### PR TITLE
update refs

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.400",
     "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,16 +9,16 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
     <PackageVersion Include="Spectre.IO" Version="0.23.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.57.2" />
     <PackageVersion Include="Spectre.IO.Testing" Version="0.23.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="Verify.ExceptionParsing" Version="31.28.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="MinVer" PrivateAssets="All" Version="7.0.0" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.1" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
     <PackageVersion Include="Spectre.IO" Version="0.23.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.57.2" />
     <PackageVersion Include="Spectre.IO.Testing" Version="0.23.0" />
@@ -17,7 +16,6 @@
     <PackageVersion Include="Verify.ExceptionParsing" Version="31.28.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="MinVer" PrivateAssets="All" Version="7.0.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.16.1" />
   </ItemGroup>

--- a/src/Verify.Terminal.IntegrationTests/GlobalUsings.cs
+++ b/src/Verify.Terminal.IntegrationTests/GlobalUsings.cs
@@ -5,7 +5,9 @@ global using Verify.Terminal;
 global using VerifyTests;
 global using VerifyXunit;
 global using Xunit;
+global using Xunit.Sdk;
+global using Xunit.v3;
 
 // Verify keeps global static naming/uniqueness state and these tests hit the real filesystem, so run
 // them serially to keep scenarios isolated.
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: Parallelization(Mode = ParallelMode.None)]

--- a/src/Verify.Terminal.IntegrationTests/Verify.Terminal.IntegrationTests.csproj
+++ b/src/Verify.Terminal.IntegrationTests/Verify.Terminal.IntegrationTests.csproj
@@ -3,17 +3,13 @@
     <!-- Multi-targeted on purpose: this exercises Verify's multi-targeting naming, where the
          received file always carries a runtime and version suffix that the verified file does not. -->
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <ProjectReference Include="..\Verify.Terminal\Verify.Terminal.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Verify.Terminal.Tests/Verify.Terminal.Tests.csproj
+++ b/src/Verify.Terminal.Tests/Verify.Terminal.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
@@ -16,14 +17,12 @@
     <EmbeddedResource Include="Data\Third\old" />
     <EmbeddedResource Include="Data\Fourth\new" />
     <EmbeddedResource Include="Data\Fourth\old" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Spectre.Console.Testing" />
     <PackageReference Include="Spectre.IO.Testing" />
     <PackageReference Include="Spectre.Verify.Extensions" />
     <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <ProjectReference Include="..\Verify.Terminal\Verify.Terminal.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**NEEDS A SQUASH ON MERGE**


# Update refs: xunit.v3 4.0

Bumps xunit.v3 from 3.2.2 to 4.0.0, plus the fallout from that major bump.

## Package updates

| Package | From | To |
|---|---|---|
| `xunit.v3` | 3.2.2 | 4.0.0 |
| `Roslynator.Analyzers` | 4.16.0 | 4.16.1 |
| SDK (`global.json`) | 10.0.100 | 10.0.400 |

## Removed packages

- **`xunit.runner.visualstudio`** — a VSTest adapter. xunit.v3 4.x runs natively on
  Microsoft.Testing.Platform (MTP), so the adapter is dead weight.
- **`Microsoft.NET.Test.Sdk`** — VSTest infrastructure, likewise unused under MTP.

Removing `Microsoft.NET.Test.Sdk` meant losing the `OutputType=Exe` it was setting
implicitly, and xunit.v3 requires test projects to be executable. Both test projects
now set `<OutputType>Exe</OutputType>` explicitly.

## Opt in to MTP mode of `dotnet test`

xunit.v3 4.0 pulls in Microsoft.Testing.Platform 2.x, which dropped the VSTest bridge
on the .NET 10 SDK. Without the opt-in, `dotnet test` fails with:

> Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on
> .NET 10 SDK and later.

The opt-in goes in `global.json`:

```json
"test": {
  "runner": "Microsoft.Testing.Platform"
}
```

Note this is the .NET 10 mechanism — the older `TestingPlatformDotnetTestSupport`
MSBuild property no longer works, since MTP 2 removed that path on .NET 10.

`build.cs` needed no change: MTP mode still accepts the solution positionally, so the
existing `DotNetTest("./src/Verify.Terminal.slnx", …)` call works as-is.

## Obsolete parallelization API

`CollectionBehaviorAttribute.DisableTestParallelization` is obsolete in 4.0, and the
build treats all warnings as errors, so this was a hard build failure. Replaced with
the new attribute in `GlobalUsings.cs`:

```csharp
[assembly: Parallelization(Mode = ParallelMode.None)]
```

Behaviour is unchanged — the integration tests still run serially, which they need to
because Verify keeps global static naming state and these tests hit the real filesystem.

## Verification

Full `dotnet build.cs` (Build → Test → Pack) is green: 54/54 tests passing across
net8.0 and net10.0, package produced, zero warnings.